### PR TITLE
Add config drive as a source for OpenStack instance metadata

### DIFF
--- a/etcd-manager/pkg/volumes/openstack/BUILD.bazel
+++ b/etcd-manager/pkg/volumes/openstack/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "openstack",
@@ -24,6 +24,19 @@ go_library(
         "//vendor/github.com/prometheus/client_golang/prometheus",
         "//vendor/gopkg.in/gcfg.v1:gcfg_v1",
         "//vendor/k8s.io/klog/v2:klog",
+        "//vendor/k8s.io/mount-utils",
         "//vendor/k8s.io/utils/exec",
+    ],
+)
+
+go_test(
+    name = "openstack_test",
+    srcs = ["volumes_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":openstack"],
+    deps = [
+        "//vendor/k8s.io/mount-utils",
+        "//vendor/k8s.io/utils/exec",
+        "//vendor/k8s.io/utils/exec/testing",
     ],
 )

--- a/etcd-manager/pkg/volumes/openstack/testdata/metadata_drive.json
+++ b/etcd-manager/pkg/volumes/openstack/testdata/metadata_drive.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "01234567-cafe-babe-beef-0123456789ab",
+    "hostname": "test-server.config.drv",
+    "name": "test-server",
+    "availability_zone": "nova",
+    "project_id": "0123456789abcdeffedcba9876543210"
+}

--- a/etcd-manager/pkg/volumes/openstack/testdata/metadata_service.json
+++ b/etcd-manager/pkg/volumes/openstack/testdata/metadata_service.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "01234567-cafe-babe-beef-0123456789ab",
+    "hostname": "test-server.serv.ice",
+    "name": "test-server",
+    "availability_zone": "nova",
+    "project_id": "0123456789abcdeffedcba9876543210"
+}

--- a/etcd-manager/pkg/volumes/openstack/volumes_test.go
+++ b/etcd-manager/pkg/volumes/openstack/volumes_test.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/mount-utils"
+	ue "k8s.io/utils/exec"
+	uet "k8s.io/utils/exec/testing"
+)
+
+const (
+	metadataIDFirst    = MetadataID + ", " + ConfigDriveID
+	configDriveIDFirst = ConfigDriveID + ", " + MetadataID
+)
+
+// expectedDriveMetadata is the metadata expected from the service endpoint
+var expectedServiceMetadata = &InstanceMetadata{
+	ServerID:         "01234567-cafe-babe-beef-0123456789ab",
+	Hostname:         "test-server.serv.ice",
+	Name:             "test-server",
+	AvailabilityZone: "nova",
+	ProjectID:        "0123456789abcdeffedcba9876543210",
+}
+
+// expectedDriveMetadata is the metadata expected from the config drive
+var expectedDriveMetadata = &InstanceMetadata{
+	ServerID:         "01234567-cafe-babe-beef-0123456789ab",
+	Hostname:         "test-server.config.drv",
+	Name:             "test-server",
+	AvailabilityZone: "nova",
+	ProjectID:        "0123456789abcdeffedcba9876543210",
+}
+
+func assertTestResults(t *testing.T, err error, expected interface{}, actual interface{}) {
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected '%+v', but got '%+v'", expected, actual)
+	}
+}
+
+// mockMetadataEndpoint mocks the actual metadata endpoint by returning the passed data
+func mockMetadataEndpoint(w http.ResponseWriter, r *http.Request, data string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, data)
+}
+
+// createMockServer creates and returns a mock HTTP server to test getting the metadata from a service endpoint
+func createMockServer() (*httptest.Server, error) {
+	data, err := os.ReadFile("testdata/metadata_service.json")
+	if err != nil {
+		return nil, err
+	}
+
+	// Note(ederst): source of inspiration https://clavinjune.dev/en/blogs/mocking-http-call-in-golang-a-better-way/
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/openstack/latest/meta_data.json") {
+			mockMetadataEndpoint(w, r, string(data))
+		} else {
+			http.NotFoundHandler().ServeHTTP(w, r)
+		}
+	}))
+
+	return mockServer, nil
+}
+
+// fakeBlkidCmd builds a fake blkid command which returns the device path of the config drive
+func fakeBlkidCmd(device string) uet.FakeCommandAction {
+	fakeCmd := &uet.FakeCmd{
+		CombinedOutputScript: []uet.FakeAction{
+			func() ([]byte, []byte, error) {
+				if device == "" {
+					return nil, nil, uet.FakeExitError{
+						Status: 2,
+					}
+				}
+				return []byte(device), nil, nil
+			},
+		},
+	}
+
+	return func(cmd string, args ...string) ue.Cmd {
+		return uet.InitFakeCmd(fakeCmd, "blkid", "-l", "-t", "LABEL=config-2", "-o", "device")
+	}
+}
+
+// getFakeMounter creates and returns a fake mounter to test getting the metadata from a config drive
+func getFakeMounter(device string) *mount.SafeFormatAndMount {
+	fakeExec := &uet.FakeExec{
+		ExactOrder: true,
+	}
+
+	fakeExec.CommandScript = append(fakeExec.CommandScript, fakeBlkidCmd(device))
+
+	return &mount.SafeFormatAndMount{
+		Interface: &mount.FakeMounter{},
+		Exec:      fakeExec,
+	}
+}
+
+func TestGetMetadataFromMetadataServiceReturnsNotFoundError(t *testing.T) {
+	mockServer, err := createMockServer()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	defer mockServer.Close()
+	metadataUrl := fmt.Sprintf("%s/%s", mockServer.URL, "no/meta_data.json")
+
+	expectedErr := fmt.Errorf("fetching metadata from '%s' returned status code '404'", metadataUrl)
+
+	_, actualErr := newMetadataService(metadataUrl, MetadataLatestPath, nil, "", MetadataID).getMetadata()
+
+	assertTestResults(t, nil, expectedErr, actualErr)
+}
+
+func TestGetMetadataFromMetadataService(t *testing.T) {
+	mockServer, err := createMockServer()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	defer mockServer.Close()
+	metadataUrl := fmt.Sprintf("%s/%s", mockServer.URL, MetadataLatestPath)
+
+	actual, err := newMetadataService(metadataUrl, MetadataLatestPath, nil, "", MetadataID).getMetadata()
+
+	assertTestResults(t, err, expectedServiceMetadata, actual)
+}
+
+func TestGetMetadataFromConfigDriveReturnsErrorWhenNoDeviceIsFound(t *testing.T) {
+	fakeMounter := getFakeMounter("")
+
+	expectedErr := fmt.Errorf("unable to run blkid: exit 2")
+
+	_, actualErr := newMetadataService("", "testdata/metadata_drive.json", fakeMounter, ".", ConfigDriveID).getMetadata()
+
+	assertTestResults(t, nil, expectedErr, actualErr)
+}
+
+func TestGetMetadataFromConfigDrive(t *testing.T) {
+	fakeMounter := getFakeMounter("/dev/sr0")
+
+	actual, err := newMetadataService("", "testdata/metadata_drive.json", fakeMounter, ".", ConfigDriveID).getMetadata()
+
+	assertTestResults(t, err, expectedDriveMetadata, actual)
+}
+
+func TestGetMetadataReturnsLastErrorWhenNoMetadataWasFound(t *testing.T) {
+	fakeMounter := getFakeMounter("")
+
+	mockServer, err := createMockServer()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	defer mockServer.Close()
+	metadataUrl := fmt.Sprintf("%s/%s", mockServer.URL, "no/meta_data.json")
+
+	expectedErr := fmt.Errorf("fetching metadata from '%s' returned status code '404'", metadataUrl)
+
+	_, actualErr := newMetadataService(metadataUrl, "testdata/metadata_drive.json", fakeMounter, ".", configDriveIDFirst).getMetadata()
+
+	assertTestResults(t, nil, expectedErr, actualErr)
+}
+
+func TestGetMetadataFromConfigDriveWhenItIsFirstInSearchOrder(t *testing.T) {
+	fakeMounter := getFakeMounter("/dev/sr0")
+
+	mockServer, err := createMockServer()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	defer mockServer.Close()
+	metadataUrl := fmt.Sprintf("%s/%s", mockServer.URL, MetadataLatestPath)
+
+	actual, err := newMetadataService(metadataUrl, "testdata/metadata_drive.json", fakeMounter, ".", configDriveIDFirst).getMetadata()
+
+	assertTestResults(t, err, expectedDriveMetadata, actual)
+}
+
+func TestGetMetadataFromServiceEndpointWhenConfigDriveFails(t *testing.T) {
+	fakeMounter := getFakeMounter("")
+
+	mockServer, err := createMockServer()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	defer mockServer.Close()
+	metadataUrl := fmt.Sprintf("%s/%s", mockServer.URL, MetadataLatestPath)
+
+	actual, err := newMetadataService(metadataUrl, "testdata/metadata_drive.json", fakeMounter, ".", configDriveIDFirst).getMetadata()
+
+	assertTestResults(t, err, expectedServiceMetadata, actual)
+}
+
+func TestGetMetadataFromServiceEndpointWhenItIsFirstInSearchOrder(t *testing.T) {
+	fakeMounter := getFakeMounter("/dev/sr0")
+
+	mockServer, err := createMockServer()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	defer mockServer.Close()
+	metadataUrl := fmt.Sprintf("%s/%s", mockServer.URL, MetadataLatestPath)
+
+	actual, err := newMetadataService(metadataUrl, "testdata/metadata_drive.json", fakeMounter, ".", metadataIDFirst).getMetadata()
+
+	assertTestResults(t, err, expectedServiceMetadata, actual)
+}
+
+func TestGetMetadataFromConfigDriveWhenServiceEndpointFails(t *testing.T) {
+	fakeMounter := getFakeMounter("/dev/sr0")
+
+	mockServer, err := createMockServer()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	defer mockServer.Close()
+	metadataUrl := fmt.Sprintf("%s/%s", mockServer.URL, "no/meta_data.json")
+
+	actual, err := newMetadataService(metadataUrl, "testdata/metadata_drive.json", fakeMounter, ".", metadataIDFirst).getMetadata()
+
+	assertTestResults(t, err, expectedDriveMetadata, actual)
+}

--- a/etcd-manager/vendor/k8s.io/utils/exec/testing/BUILD.bazel
+++ b/etcd-manager/vendor/k8s.io/utils/exec/testing/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "testing",
+    srcs = ["fake_exec.go"],
+    importmap = "sigs.k8s.io/etcdadm/etcd-manager/vendor/k8s.io/utils/exec/testing",
+    importpath = "k8s.io/utils/exec/testing",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/utils/exec"],
+)

--- a/etcd-manager/vendor/k8s.io/utils/exec/testing/fake_exec.go
+++ b/etcd-manager/vendor/k8s.io/utils/exec/testing/fake_exec.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testingexec
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"k8s.io/utils/exec"
+)
+
+// FakeExec is a simple scripted Interface type.
+type FakeExec struct {
+	CommandScript []FakeCommandAction
+	CommandCalls  int
+	LookPathFunc  func(string) (string, error)
+	// ExactOrder enforces that commands are called in the order they are scripted,
+	// and with the exact same arguments
+	ExactOrder bool
+	// DisableScripts removes the requirement that a slice of FakeCommandAction be
+	// populated before calling Command(). This makes the fakeexec (and subsequent
+	// calls to Run() or CombinedOutput() always return success and there is no
+	// ability to set their output.
+	DisableScripts bool
+}
+
+var _ exec.Interface = &FakeExec{}
+
+// FakeCommandAction is the function to be executed
+type FakeCommandAction func(cmd string, args ...string) exec.Cmd
+
+// Command is to track the commands that are executed
+func (fake *FakeExec) Command(cmd string, args ...string) exec.Cmd {
+	if fake.DisableScripts {
+		fakeCmd := &FakeCmd{DisableScripts: true}
+		return InitFakeCmd(fakeCmd, cmd, args...)
+	}
+	if fake.CommandCalls > len(fake.CommandScript)-1 {
+		panic(fmt.Sprintf("ran out of Command() actions. Could not handle command [%d]: %s args: %v", fake.CommandCalls, cmd, args))
+	}
+	i := fake.CommandCalls
+	fake.CommandCalls++
+	fakeCmd := fake.CommandScript[i](cmd, args...)
+	if fake.ExactOrder {
+		argv := append([]string{cmd}, args...)
+		fc := fakeCmd.(*FakeCmd)
+		if cmd != fc.Argv[0] {
+			panic(fmt.Sprintf("received command: %s, expected: %s", cmd, fc.Argv[0]))
+		}
+		if len(argv) != len(fc.Argv) {
+			panic(fmt.Sprintf("command (%s) received with extra/missing arguments. Expected %v, Received %v", cmd, fc.Argv, argv))
+		}
+		for i, a := range argv[1:] {
+			if a != fc.Argv[i+1] {
+				panic(fmt.Sprintf("command (%s) called with unexpected argument. Expected %s, Received %s", cmd, fc.Argv[i+1], a))
+			}
+		}
+	}
+	return fakeCmd
+}
+
+// CommandContext wraps arguments into exec.Cmd
+func (fake *FakeExec) CommandContext(ctx context.Context, cmd string, args ...string) exec.Cmd {
+	return fake.Command(cmd, args...)
+}
+
+// LookPath is for finding the path of a file
+func (fake *FakeExec) LookPath(file string) (string, error) {
+	return fake.LookPathFunc(file)
+}
+
+// FakeCmd is a simple scripted Cmd type.
+type FakeCmd struct {
+	Argv                 []string
+	CombinedOutputScript []FakeAction
+	CombinedOutputCalls  int
+	CombinedOutputLog    [][]string
+	OutputScript         []FakeAction
+	OutputCalls          int
+	OutputLog            [][]string
+	RunScript            []FakeAction
+	RunCalls             int
+	RunLog               [][]string
+	Dirs                 []string
+	Stdin                io.Reader
+	Stdout               io.Writer
+	Stderr               io.Writer
+	Env                  []string
+	StdoutPipeResponse   FakeStdIOPipeResponse
+	StderrPipeResponse   FakeStdIOPipeResponse
+	WaitResponse         error
+	StartResponse        error
+	DisableScripts       bool
+}
+
+var _ exec.Cmd = &FakeCmd{}
+
+// InitFakeCmd is for creating a fake exec.Cmd
+func InitFakeCmd(fake *FakeCmd, cmd string, args ...string) exec.Cmd {
+	fake.Argv = append([]string{cmd}, args...)
+	return fake
+}
+
+// FakeStdIOPipeResponse holds responses to use as fakes for the StdoutPipe and
+// StderrPipe method calls
+type FakeStdIOPipeResponse struct {
+	ReadCloser io.ReadCloser
+	Error      error
+}
+
+// FakeAction is a function type
+type FakeAction func() ([]byte, []byte, error)
+
+// SetDir sets the directory
+func (fake *FakeCmd) SetDir(dir string) {
+	fake.Dirs = append(fake.Dirs, dir)
+}
+
+// SetStdin sets the stdin
+func (fake *FakeCmd) SetStdin(in io.Reader) {
+	fake.Stdin = in
+}
+
+// SetStdout sets the stdout
+func (fake *FakeCmd) SetStdout(out io.Writer) {
+	fake.Stdout = out
+}
+
+// SetStderr sets the stderr
+func (fake *FakeCmd) SetStderr(out io.Writer) {
+	fake.Stderr = out
+}
+
+// SetEnv sets the environment variables
+func (fake *FakeCmd) SetEnv(env []string) {
+	fake.Env = env
+}
+
+// StdoutPipe returns an injected ReadCloser & error (via StdoutPipeResponse)
+// to be able to inject an output stream on Stdout
+func (fake *FakeCmd) StdoutPipe() (io.ReadCloser, error) {
+	return fake.StdoutPipeResponse.ReadCloser, fake.StdoutPipeResponse.Error
+}
+
+// StderrPipe returns an injected ReadCloser & error (via StderrPipeResponse)
+// to be able to inject an output stream on Stderr
+func (fake *FakeCmd) StderrPipe() (io.ReadCloser, error) {
+	return fake.StderrPipeResponse.ReadCloser, fake.StderrPipeResponse.Error
+}
+
+// Start mimicks starting the process (in the background) and returns the
+// injected StartResponse
+func (fake *FakeCmd) Start() error {
+	return fake.StartResponse
+}
+
+// Wait mimicks waiting for the process to exit returns the
+// injected WaitResponse
+func (fake *FakeCmd) Wait() error {
+	return fake.WaitResponse
+}
+
+// Run runs the command
+func (fake *FakeCmd) Run() error {
+	if fake.DisableScripts {
+		return nil
+	}
+	if fake.RunCalls > len(fake.RunScript)-1 {
+		panic("ran out of Run() actions")
+	}
+	if fake.RunLog == nil {
+		fake.RunLog = [][]string{}
+	}
+	i := fake.RunCalls
+	fake.RunLog = append(fake.RunLog, append([]string{}, fake.Argv...))
+	fake.RunCalls++
+	stdout, stderr, err := fake.RunScript[i]()
+	if stdout != nil {
+		fake.Stdout.Write(stdout)
+	}
+	if stderr != nil {
+		fake.Stderr.Write(stderr)
+	}
+	return err
+}
+
+// CombinedOutput returns the output from the command
+func (fake *FakeCmd) CombinedOutput() ([]byte, error) {
+	if fake.DisableScripts {
+		return []byte{}, nil
+	}
+	if fake.CombinedOutputCalls > len(fake.CombinedOutputScript)-1 {
+		panic("ran out of CombinedOutput() actions")
+	}
+	if fake.CombinedOutputLog == nil {
+		fake.CombinedOutputLog = [][]string{}
+	}
+	i := fake.CombinedOutputCalls
+	fake.CombinedOutputLog = append(fake.CombinedOutputLog, append([]string{}, fake.Argv...))
+	fake.CombinedOutputCalls++
+	stdout, _, err := fake.CombinedOutputScript[i]()
+	return stdout, err
+}
+
+// Output is the response from the command
+func (fake *FakeCmd) Output() ([]byte, error) {
+	if fake.DisableScripts {
+		return []byte{}, nil
+	}
+	if fake.OutputCalls > len(fake.OutputScript)-1 {
+		panic("ran out of Output() actions")
+	}
+	if fake.OutputLog == nil {
+		fake.OutputLog = [][]string{}
+	}
+	i := fake.OutputCalls
+	fake.OutputLog = append(fake.OutputLog, append([]string{}, fake.Argv...))
+	fake.OutputCalls++
+	stdout, _, err := fake.OutputScript[i]()
+	return stdout, err
+}
+
+// Stop is to stop the process
+func (fake *FakeCmd) Stop() {
+	// no-op
+}
+
+// FakeExitError is a simple fake ExitError type.
+type FakeExitError struct {
+	Status int
+}
+
+var _ exec.ExitError = FakeExitError{}
+
+func (fake FakeExitError) String() string {
+	return fmt.Sprintf("exit %d", fake.Status)
+}
+
+func (fake FakeExitError) Error() string {
+	return fake.String()
+}
+
+// Exited always returns true
+func (fake FakeExitError) Exited() bool {
+	return true
+}
+
+// ExitStatus returns the fake status
+func (fake FakeExitError) ExitStatus() int {
+	return fake.Status
+}

--- a/etcd-manager/vendor/modules.txt
+++ b/etcd-manager/vendor/modules.txt
@@ -536,6 +536,7 @@ k8s.io/mount-utils
 ## explicit; go 1.12
 k8s.io/utils/clock
 k8s.io/utils/exec
+k8s.io/utils/exec/testing
 k8s.io/utils/internal/third_party/forked/golang/net
 k8s.io/utils/io
 k8s.io/utils/keymutex


### PR DESCRIPTION
This is a copy of https://github.com/kubernetes-sigs/etcdadm/pull/318 to make it available on our fork.